### PR TITLE
docs: use a human-readable README title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ep_rss
+# RSS Feeds of Pad Changes for Etherpad
 
 ![Publish Status](https://github.com/ether/ep_rss/workflows/Node.js%20Package/badge.svg) [![Backend Tests Status](https://github.com/ether/ep_rss/actions/workflows/test-and-release.yml/badge.svg)](https://github.com/ether/ep_rss/actions/workflows/test-and-release.yml)
 


### PR DESCRIPTION
Replace the placeholder `ep_rss` heading in README.md with "RSS Feeds of Pad Changes for Etherpad" so browsers of the plugin list on GitHub / npm can see what the plugin does at a glance.