### PR TITLE
fix: load API hook on TS-source Etherpad and migrate routes to Express 5

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const API = require('ep_etherpad-lite/node/db/API.js');
+const API = require('ep_etherpad-lite/node/db/API');
 const padManager = require('ep_etherpad-lite/node/db/PadManager');
 const settings = require('ep_etherpad-lite/node/utils/Settings');
 
@@ -20,33 +20,16 @@ exports.eejsBlock_htmlHead = (hookName, args, cb) => {
 };
 
 exports.registerRoute = (hookName, args, cb) => {
-  args.app.get('/p/*/rss', (req, res) => {
-    /* Sanity is in the crack of time*/
-    const path = req.url.split('/');
-    const padId = path[2];
-    res.redirect(`/p/${padId}/feed`);
-  });
+  const redirectToFeed = (req, res) => {
+    res.redirect(`/p/${encodeURIComponent(req.params.padId)}/feed`);
+  };
+  args.app.get('/p/:padId/rss', redirectToFeed);
+  args.app.get('/p/:padId/feed.rss', redirectToFeed);
+  args.app.get('/p/:padId/atom.xml', redirectToFeed);
 
-  args.app.get('/p/*/feed.rss', (req, res) => {
-    /* Sanity is in the crack of time*/
-    const path = req.url.split('/');
-    const padId = path[2];
-    res.redirect(`/p/${padId}/feed`);
-  });
-
-
-  args.app.get('/p/*/atom.xml', (req, res) => {
-    /* Sanity is in the crack of time*/
-    const path = req.url.split('/');
-    const padId = path[2];
-    res.redirect(`/p/${padId}/feed`);
-  });
-
-  args.app.get('/p/*/feed', async (req, res) => {
-    /* Sanity is in the cracks of lime*/
+  args.app.get('/p/:padId/feed', async (req, res) => {
     const fullURL = `${req.protocol}://${req.get('host')}${req.url}`;
-    const path = req.url.split('/');
-    const padId = path[2];
+    const padId = req.params.padId;
     const padURL = `${req.protocol}://${req.get('host')}/p/${padId}`;
     const dateString = new Date();
     let isPublished = false; // is this item already published?

--- a/static/tests/frontend-new/specs/feed.spec.ts
+++ b/static/tests/frontend-new/specs/feed.spec.ts
@@ -1,0 +1,54 @@
+import {expect, test} from '@playwright/test';
+import {goToNewPad, writeToPad} from 'ep_etherpad-lite/tests/frontend-new/helper/padHelper';
+
+const BASE_URL = 'http://localhost:9001';
+
+const padIdFromUrl = (url: string) => url.split('/p/')[1].split('?')[0];
+
+test.describe('ep_rss feed', () => {
+  test('declares the RSS alternate link in the pad page head', async ({page}) => {
+    await goToNewPad(page);
+    const link = page.locator('head link[rel="alternate"][type="application/rss+xml"]');
+    await expect(link).toHaveAttribute('href', 'feed');
+  });
+
+  test('serves an RSS document at /p/<pad>/feed containing the pad text', async ({page, request}) => {
+    await goToNewPad(page);
+    const padId = padIdFromUrl(page.url());
+    const marker = `ep-rss-marker-${Date.now()}`;
+    await writeToPad(page, marker);
+    // Give the socket time to flush the change to the pad store before the
+    // route reads it back via API.getLastEdited / padManager.getPad.
+    await page.waitForTimeout(1200);
+
+    const res = await request.get(`${BASE_URL}/p/${padId}/feed`);
+    expect(res.status()).toBe(200);
+    expect(res.headers()['content-type']).toContain('application/rss+xml');
+    const body = await res.text();
+    expect(body).toMatch(/^<rss /);
+    expect(body).toContain(`<title>${padId}</title>`);
+    expect(body).toContain(marker);
+    expect(body.trim().endsWith('</rss>')).toBe(true);
+  });
+
+  test('escapes HTML special characters in the description', async ({page, request}) => {
+    await goToNewPad(page);
+    const padId = padIdFromUrl(page.url());
+    await writeToPad(page, 'tags <b>&</b>');
+    await page.waitForTimeout(1200);
+
+    const body = await (await request.get(`${BASE_URL}/p/${padId}/feed`)).text();
+    expect(body).toContain('&lt;b&gt;&amp;&lt;/b&gt;');
+    expect(body).not.toContain('<b>&</b>');
+  });
+
+  for (const alias of ['rss', 'feed.rss', 'atom.xml']) {
+    test(`/p/<pad>/${alias} redirects to /p/<pad>/feed`, async ({page, request}) => {
+      await goToNewPad(page);
+      const padId = padIdFromUrl(page.url());
+      const res = await request.get(`${BASE_URL}/p/${padId}/${alias}`, {maxRedirects: 0});
+      expect(res.status()).toBe(302);
+      expect(res.headers()['location']).toBe(`/p/${padId}/feed`);
+    });
+  }
+});


### PR DESCRIPTION
## Summary

`ep_rss@11.0.24` no longer registers any hooks on a current Etherpad. Two independent breakages had piled up since the last release:

1. **`require('ep_etherpad-lite/node/db/API.js')`** — `node/db/API` is now `API.ts`. `tsx/cjs` happily resolves `require('.../API')` to the `.ts` file but it does **not** rewrite a hard-coded `.js` request, so the require throws `Cannot find module ...API.js` and both `eejsBlock_htmlHead` and `expressCreateServer` fail to load. The other two `ep_etherpad-lite/node/...` imports in the same file are already extensionless.
2. **`/p/*/{rss,feed.rss,atom.xml,feed}`** — path-to-regexp v8 (shipped with Express 5, which Etherpad runs on) rejects the bare `*` wildcard with `TypeError: Missing parameter name at index 4: /p/*/rss`. Replace it with a named `:padId` parameter, read the id from `req.params.padId` instead of slicing `req.url`, and `encodeURIComponent()` the value on the redirect so pad names with reserved characters land at a well-formed URL.

After both fixes the feed serves `application/rss+xml` for a real pad, and the three legacy paths return 302 to `/feed`.

## Test plan

- [x] `pnpm run plugins i ep_rss` + `pnpm run dev` on a current Etherpad checkout — server starts, no "Failed to load hook function" entries in the log.
- [x] `curl -i http://127.0.0.1:9001/p/<pad>/feed` returns `200 OK` with `Content-Type: application/rss+xml; charset=utf-8` and a parseable `<rss>` body (verified after seeding the pad via `etherpad-cli-client`).
- [x] `curl -i http://127.0.0.1:9001/p/<pad>/rss`, `/feed.rss`, and `/atom.xml` each return `302` with `Location: /p/<pad>/feed`.
- [ ] CI (frontend + backend Playwright smoke) green on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)